### PR TITLE
Fix naming convention

### DIFF
--- a/concrete/src/Page/Command/CopyPageCommand.php
+++ b/concrete/src/Page/Command/CopyPageCommand.php
@@ -16,11 +16,11 @@ class CopyPageCommand extends PageCommand implements BatchableCommandInterface
      */
     protected $isMultilingual;
 
-    public function __construct(int $pageID, int $destinationPageID, bool $isMultilingual = false)
+    public function __construct(int $pageID, int $destinationPageID, bool $multilingualCopy = false)
     {
         parent::__construct($pageID);
         $this->setDestinationPageID($destinationPageID);
-        $this->isMultilingual = $isMultilingual;
+        $this->isMultilingual = $multilingualCopy;
     }
 
     /**


### PR DESCRIPTION
Bernard saves isMultilingualCopy in the database as multilingualCopy and since it doesn't exist on the constructor it gets ignored.
So we just change this and its fixed
